### PR TITLE
Generate lists in RPZ format

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ If you are absolutely sure you want to block all disguised trackers even if it b
 * `AdGuard CNAME disguised trackers list` - The list of trackers that disguise the real trackers by using CNAME records. Use in any traditional content blocker.
     * [Adblock-style syntax](https://github.com/AdguardTeam/AdGuardHome/wiki/Hosts-Blocklists#adblock-style): https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers.txt
     * [Just domain names](https://github.com/AdguardTeam/AdGuardHome/wiki/Hosts-Blocklists#adblock-style): https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_justdomains.txt
+
+If you run your own DNS server which supports [Response Policy Zones](https://www.dnsrpz.info), use the data in RPZ format:
+
+* `AdGuard CNAME disguised trackers list` - The list of trackers that disguise the real trackers by using CNAME records. Use with a compatible DNS server implementation.
+    * [Response Policy Zone (RPZ) format](https://github.com/AdguardTeam/AdGuardHome/wiki/Hosts-Blocklists#adblock-style): https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_rpz.txt
+
+You will need to prepend your own SOA and NS records.  Consult the documentation of your DNS server and/or the [IETF Draft](https://datatracker.ietf.org/doc/draft-vixie-dnsop-dns-rpz/) for more information.

--- a/script/index.js
+++ b/script/index.js
@@ -11,6 +11,7 @@ const {
     INFO_FILE_EXTENSION,
     RULES_FILE_EXTENSION,
     HOSTS_RULES_FILE_NAME_ENDING,
+    RPZ_RULES_FILE_NAME_ENDING,
 } = require('./src/constants');
 const { TRACKERS_DIR } = require('./config');
 const { buildDesc } = require('./src/build-desc');
@@ -73,7 +74,7 @@ const main = async () => {
             await fs.writeFile(path.resolve(__dirname, TRACKERS_DIR, `${companyFileName}.md`), descString);
 
             const {
-                baseRulesString, hostsRulesString,
+                baseRulesString, hostsRulesString, rpzRulesString,
             } = await buildRules(trackersData);
             await fs.writeFile(
                 path.resolve(
@@ -90,6 +91,14 @@ const main = async () => {
                     `${companyFileName}${HOSTS_RULES_FILE_NAME_ENDING}.${RULES_FILE_EXTENSION}`,
                 ),
                 hostsRulesString,
+            );
+            await fs.writeFile(
+                path.resolve(
+                    __dirname,
+                    TRACKERS_DIR,
+                    `${companyFileName}${RPZ_RULES_FILE_NAME_ENDING}.${RULES_FILE_EXTENSION}`,
+                ),
+                rpzRulesString,
             );
             const doneNumStr = i === trackersLength - 1 ? '100%' : `~${Math.round(((i + 1) / trackersLength) * 100)}%`;
             console.log(`Successfully fetched for tracker: ${companyName}, ${doneNumStr} done`);

--- a/script/src/build-rules.js
+++ b/script/src/build-rules.js
@@ -7,7 +7,7 @@ const { CONST_DATA } = require('./constants');
 /**
  * Builds rules content by type
  * @param {TrackersData} trackersData
- * @param {'BASE'|'HOSTS'} type rules type
+ * @param {'BASE'|'HOSTS'|'RPZ'} type rules type
  * @returns {string}
  */
 const buildRulesByType = (trackersData, type) => {
@@ -35,6 +35,8 @@ const buildRulesByType = (trackersData, type) => {
                     rule = `||${disguise}^`;
                 } else if (type === CONST_DATA.HOSTS.type) {
                     rule = disguise;
+                } else if (type === CONST_DATA.RPZ.type) {
+                    rule = `${disguise} CNAME .`;
                 }
                 rulesChunks.push(rule);
             });
@@ -42,6 +44,11 @@ const buildRulesByType = (trackersData, type) => {
             rulesChunks.push(`${CONST_DATA[type].commentMarker} no domains found for ${domainName}`);
         }
     });
+
+    /* Ensure there is a newline at the end of RPZ files. */
+    if (type === CONST_DATA.RPZ.type) {
+        rulesChunks.length++;
+    }
 
     const baseRulesString = rulesChunks.join('\n');
     return baseRulesString;
@@ -51,6 +58,7 @@ const buildRulesByType = (trackersData, type) => {
  * @typedef {Object} RulesContent
  * @property {string} baseRulesString
  * @property {string} hostsRulesString
+ * @property {string} rpzRulesString
  */
 
 /**
@@ -61,8 +69,9 @@ const buildRulesByType = (trackersData, type) => {
 const buildRules = async (trackersData) => {
     const baseRulesString = buildRulesByType(trackersData, CONST_DATA.BASE.type);
     const hostsRulesString = buildRulesByType(trackersData, CONST_DATA.HOSTS.type);
+    const rpzRulesString = buildRulesByType(trackersData, CONST_DATA.RPZ.type);
 
-    return { baseRulesString, hostsRulesString };
+    return { baseRulesString, hostsRulesString, rpzRulesString };
 };
 
 module.exports = { buildRules };

--- a/script/src/constants.js
+++ b/script/src/constants.js
@@ -1,5 +1,6 @@
 const BASE_RULE_COMMENT_MARKER = '!';
 const HOSTS_RULE_COMMENT_MARKER = '#';
+const RPZ_RULE_COMMENT_MARKER = ';';
 
 const COMBINED_DISGUISES_HEADER_TITLE = 'Title: AdGuard CNAME disguised trackers list';
 const COMBINED_DISGUISES_HEADER_DESC = 'Description: The list of trackers that disguise the real trackers by using CNAME records.';
@@ -12,10 +13,12 @@ const RULES_FILE_EXTENSION = 'txt';
 
 const COMBINED_RULES_FILE_NAME_BASE = 'combined_disguised_trackers';
 const HOSTS_RULES_FILE_NAME_ENDING = '_justdomains';
+const RPZ_RULES_FILE_NAME_ENDING = '_rpz';
 const COMBINED_ORIGINALS_FILE_NAME_BASE = 'combined_original_trackers';
 
 const COMBINED_BASE_RULES_FILE_NAME = `${COMBINED_RULES_FILE_NAME_BASE}.${RULES_FILE_EXTENSION}`;
 const COMBINED_HOSTS_RULES_FILE_NAME = `${COMBINED_RULES_FILE_NAME_BASE}${HOSTS_RULES_FILE_NAME_ENDING}.${RULES_FILE_EXTENSION}`;
+const COMBINED_RPZ_RULES_FILE_NAME = `${COMBINED_RULES_FILE_NAME_BASE}${RPZ_RULES_FILE_NAME_ENDING}.${RULES_FILE_EXTENSION}`;
 const COMBINED_ORIGINALS_FILE_NAME = `${COMBINED_ORIGINALS_FILE_NAME_BASE}.${RULES_FILE_EXTENSION}`;
 const COMBINED_JSON_FILE_NAME = `${COMBINED_RULES_FILE_NAME_BASE}.${INFO_FILE_EXTENSION}`;
 
@@ -33,6 +36,13 @@ const hostsRulesCombinedHeader = [
     `${HOSTS_RULE_COMMENT_MARKER}`,
 ].join('\n');
 
+const rpzRulesCombinedHeader = [
+    `${RPZ_RULE_COMMENT_MARKER} ${COMBINED_DISGUISES_HEADER_TITLE}`,
+    `${RPZ_RULE_COMMENT_MARKER} ${COMBINED_DISGUISES_HEADER_DESC}`,
+    `${RPZ_RULE_COMMENT_MARKER} ${COMBINED_FILTER_LIST_HEADER_HOMEPAGE}`,
+    `${RPZ_RULE_COMMENT_MARKER}`,
+].join('\n');
+
 const originalsCombinedHeader = [
     `${BASE_RULE_COMMENT_MARKER} ${COMBINED_ORIGINAL_TRACKERS_HEADER_TITLE}`,
     `${BASE_RULE_COMMENT_MARKER} ${COMBINED_ORIGINAL_TRACKERS_HEADER_DESC}`,
@@ -42,6 +52,7 @@ const originalsCombinedHeader = [
 
 const BASE_RULES_TYPE = 'BASE';
 const HOSTS_RULES_TYPE = 'HOSTS';
+const RPZ_RULES_TYPE = 'RPZ';
 
 const CONST_DATA = {
     [BASE_RULES_TYPE]: {
@@ -56,6 +67,12 @@ const CONST_DATA = {
         combinedHeader: hostsRulesCombinedHeader,
         combinedFileName: COMBINED_HOSTS_RULES_FILE_NAME,
     },
+    [RPZ_RULES_TYPE]: {
+        type: RPZ_RULES_TYPE,
+        commentMarker: RPZ_RULE_COMMENT_MARKER,
+        combinedHeader: rpzRulesCombinedHeader,
+        combinedFileName: COMBINED_RPZ_RULES_FILE_NAME,
+    },
     ORIGINALS: {
         commentMarker: BASE_RULE_COMMENT_MARKER,
         combinedHeader: originalsCombinedHeader,
@@ -66,9 +83,11 @@ const CONST_DATA = {
 module.exports = {
     BASE_RULE_COMMENT_MARKER,
     HOSTS_RULE_COMMENT_MARKER,
+    RPZ_RULE_COMMENT_MARKER,
     RULES_FILE_EXTENSION,
     INFO_FILE_EXTENSION,
     COMBINED_JSON_FILE_NAME,
     HOSTS_RULES_FILE_NAME_ENDING,
+    RPZ_RULES_FILE_NAME_ENDING,
     CONST_DATA,
 };

--- a/script/src/update-combined.js
+++ b/script/src/update-combined.js
@@ -5,6 +5,7 @@ const {
     INFO_FILE_EXTENSION,
     COMBINED_JSON_FILE_NAME,
     HOSTS_RULES_FILE_NAME_ENDING,
+    RPZ_RULES_FILE_NAME_ENDING,
     CONST_DATA,
 } = require('./constants');
 const { formatFilename } = require('./helpers');
@@ -46,7 +47,7 @@ const updateCombined = async () => {
         originalTrackersCombinedChunks.join('\n'),
     );
 
-    // update base and hosts rules combined files
+    // update base, hosts and rpz rules combined files
     const companyFileNames = originalTrackers
         .map(({ company_name: companyName }) => formatFilename(companyName));
 
@@ -58,12 +59,19 @@ const updateCombined = async () => {
         const hostsFileName = `${rawFileName}${HOSTS_RULES_FILE_NAME_ENDING}.${RULES_FILE_EXTENSION}`;
         return hostsFileName;
     });
+    const rpzRulesFileNames = companyFileNames.map((rawFileName) => {
+        const rpzFileName = `${rawFileName}${RPZ_RULES_FILE_NAME_ENDING}.${RULES_FILE_EXTENSION}`;
+        return rpzFileName;
+    });
 
     const baseCombinedStr = await combineFiles(
         baseRulesFileNames, CONST_DATA.BASE.combinedHeader,
     );
     const hostsCombinedStr = await combineFiles(
         hostsRulesFileNames, CONST_DATA.HOSTS.combinedHeader,
+    );
+    const rpzCombinedStr = await combineFiles(
+        rpzRulesFileNames, CONST_DATA.RPZ.combinedHeader,
     );
 
     await fs.writeFile(
@@ -73,6 +81,10 @@ const updateCombined = async () => {
     await fs.writeFile(
         path.resolve(__dirname, ROOT_DIR_PATH, CONST_DATA.HOSTS.combinedFileName),
         hostsCombinedStr,
+    );
+    await fs.writeFile(
+        path.resolve(__dirname, ROOT_DIR_PATH, CONST_DATA.RPZ.combinedFileName),
+        rpzCombinedStr,
     );
 
     // update combined_disguise_trackers.json


### PR DESCRIPTION
As discussed in issue #13, it would be very convenient if the combined disguised trackers list were made available as a DNS Response Policy Zone.  This pull request implements exactly that.

New _rpz.txt files are generated per tracker with the records formatted as `CNAME .` NXDOMAIN RPZ actions. A new combined_disguised_trackers_rpz.txt file combines these files into one easy to use list.