### PR TITLE
Added AdSpyglass ad server

### DIFF
--- a/script/src/cloaked-trackers.json
+++ b/script/src/cloaked-trackers.json
@@ -18,6 +18,12 @@
         ]
     },
     {
+        "company_name": "AdSpyglass",
+        "domains": [
+            "0i0i0i0.com"
+        ]
+    },
+    {
         "company_name": "AT Internet (formerly XiTi)",
         "domains": [
             "at-o.net"


### PR DESCRIPTION
AdSpyglass is using some random domains, for example `mousecatzilla.com` and `profield.ddns.net` which can be blocked by `0i0i0i0.com` CNAME. So I think that it would be a good idea to add `0i0i0i0.com` to "cloaked trackers" to find more similar domains.

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/29142494/142411992-44c50c52-e6f8-40ec-89dc-a811b3371cbb.png)

</details>