### PR TITLE
Remove beyondmeasure.rigoltech.com as it's used to download firmware updates from

### DIFF
--- a/data/combined_disguised_trackers.json
+++ b/data/combined_disguised_trackers.json
@@ -11697,7 +11697,6 @@
   "besucher.nona.de": "custom.plausible.io",
   "beta-twtelecom.azure.net.daraz.com": "daraz-com.affex.org",
   "bewnfl.houseoftents.co.uk": "gum.fr3.vip.prod.criteo.com",
-  "beyondmeasure.rigoltech.com": "forpci73.actonsoftware.com",
   "bf4yuoa53tjo3ckz.dcsportal.0-astrologie.net.daraz.com": "daraz-com.affex.org",
   "bf4yuoa53tjo3ckz.northamerica.net.daraz.com": "daraz-com.affex.org",
   "bf4yuoa53tjo3ckz.partner.net.daraz.com": "daraz-com.affex.org",

--- a/data/combined_disguised_trackers.txt
+++ b/data/combined_disguised_trackers.txt
@@ -11701,7 +11701,6 @@
 ||besucher.nona.de^
 ||beta-twtelecom.azure.net.daraz.com^
 ||bewnfl.houseoftents.co.uk^
-||beyondmeasure.rigoltech.com^
 ||bf4yuoa53tjo3ckz.dcsportal.0-astrologie.net.daraz.com^
 ||bf4yuoa53tjo3ckz.northamerica.net.daraz.com^
 ||bf4yuoa53tjo3ckz.partner.net.daraz.com^

--- a/data/combined_disguised_trackers_justdomains.txt
+++ b/data/combined_disguised_trackers_justdomains.txt
@@ -11701,7 +11701,6 @@ bestwesterninternati.tt.omtrdc.net
 besucher.nona.de
 beta-twtelecom.azure.net.daraz.com
 bewnfl.houseoftents.co.uk
-beyondmeasure.rigoltech.com
 bf4yuoa53tjo3ckz.dcsportal.0-astrologie.net.daraz.com
 bf4yuoa53tjo3ckz.northamerica.net.daraz.com
 bf4yuoa53tjo3ckz.partner.net.daraz.com

--- a/data/combined_disguised_trackers_rpz.txt
+++ b/data/combined_disguised_trackers_rpz.txt
@@ -11712,7 +11712,6 @@ bestwesterninternati.tt.omtrdc.net CNAME .
 besucher.nona.de CNAME .
 beta-twtelecom.azure.net.daraz.com CNAME .
 bewnfl.houseoftents.co.uk CNAME .
-beyondmeasure.rigoltech.com CNAME .
 bf4yuoa53tjo3ckz.dcsportal.0-astrologie.net.daraz.com CNAME .
 bf4yuoa53tjo3ckz.northamerica.net.daraz.com CNAME .
 bf4yuoa53tjo3ckz.partner.net.daraz.com CNAME .


### PR DESCRIPTION
When trying to update the firmware of my Oscilloscope, it took forever. When trying to manually download it from their site, it turns out that the download link leads to a blocked domain.

![grafik](https://github.com/user-attachments/assets/5498c611-e7b4-4afa-b3cc-5678d7bfcc6f)

![grafik](https://github.com/user-attachments/assets/2f7ba203-e0a3-4ff3-8561-9cce6610f0bd)